### PR TITLE
FlexWidget flexibler gemacht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Leading Systems Contao Helpers bundle changelog
 ===========================================
 
+### 3.1.1 (2026-06-26)
+ * improve FlexWidget: add Getter
+
 ### 3.1.0 (2025-07-18)
  * improve insertTag
  * feature getPageDetailsCached()

--- a/src/Resources/contao/classes/FlexWidget.php
+++ b/src/Resources/contao/classes/FlexWidget.php
@@ -321,6 +321,10 @@ class FlexWidget
 		return $this->var_value;
 	}
 
+	public function getMoreData(): array {
+		return $this->arr_moreData;
+	}
+
 	public function getOutput() {
 		return $this->str_output;
 	}

--- a/src/Resources/contao/templates/flexWidget/ls_flexWidget_defaultNumber.html5
+++ b/src/Resources/contao/templates/flexWidget/ls_flexWidget_defaultNumber.html5
@@ -9,13 +9,19 @@
     <input
             name="<?php echo $this->str_name; ?>" id="<?php echo $this->str_name; ?>"
             type="number"
-            min="0"
+            min="<?php echo $this->arr_moreData['min'] ?? '0'; ?>"
             value="<?php echo $this->var_value; ?>"
+        <?php if (isset($this->arr_moreData['max'])) { ?>
+            max="<?php echo $this->arr_moreData['max']; ?>"
+        <?php } ?>
 
-        <?php if(isset($this->arr_moreData['decimalsAmount']) && $this->arr_moreData['decimalsAmount'] > 0){ ?>
+        <?php if (isset($this->arr_moreData['step'])) { ?>
+            step="<?php echo $this->arr_moreData['step']; ?>"
+            inputmode="<?php echo $this->arr_moreData['inputmode'] ?? 'numeric'; ?>"
+        <?php } elseif (isset($this->arr_moreData['decimalsAmount']) && $this->arr_moreData['decimalsAmount'] > 0) { ?>
             step="<?=pow(10, -$this->arr_moreData['decimalsAmount'])?>"
             inputmode="decimal"
-        <?php }else{ ?>
+        <?php } else { ?>
             step="1"
             inputmode="numeric"
         <?php } ?>


### PR DESCRIPTION
Das Flex-Widget musste flexibler gemacht werden.
- Ein öffentlicher Getter für das Property arr_moreData wurde benötigt, weil Code im Merconis-Core diese Daten lesen können muss.
- Das Number-Feld (ls_flexWidget_defaultNumber) wurde bzgl. der min/max/step-Parameter flexibler gemacht (diese können über arr_moreData nun direkt gesteuert werden)